### PR TITLE
Preparation for release 5.0.0

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -14,8 +14,8 @@
       <module name="data-generator" target="1.7" />
       <module name="datagenerator" target="9" />
       <module name="dmt" target="1.8" />
-      <module name="generator" target="8" />
       <module name="test" target="9" />
+      <module name="generator" target="17" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -12,7 +12,8 @@
       </set>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -134,8 +134,8 @@
    </distributionManagement>
    <properties>
       <org.junit.platform.version>1.3.0</org.junit.platform.version>
-      <org.junit.jupiter.version>5.4.0</org.junit.jupiter.version>
-      <maven-surefire-plugin.version>3.0.0-M1</maven-surefire-plugin.version>
+      <org.junit.jupiter.version>5.4.2</org.junit.jupiter.version>
+      <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
       <slf4j-log4j2-version>2.0.1</slf4j-log4j2-version>
       <gpg-plugin-version>1.6</gpg-plugin-version>
       <release-plugin-version>2.5.3</release-plugin-version>
@@ -194,7 +194,7 @@
       <dependency>
          <groupId>org.json</groupId>
          <artifactId>json</artifactId>
-         <version>20140107</version>
+         <version>20210307</version>
       </dependency>
 
       <!--Math Expressions-->
@@ -203,13 +203,11 @@
          <artifactId>exp4j</artifactId>
          <version>0.4.8</version>
       </dependency>
-
       <dependency>
          <groupId>org.apache.httpcomponents</groupId>
          <artifactId>httpclient</artifactId>
-         <version>4.5.3</version>
+         <version>4.5.13</version>
       </dependency>
-
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-api</artifactId>
@@ -219,7 +217,7 @@
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-simple</artifactId>
-         <version>1.7.5</version>
+         <version>1.7.36</version>
       </dependency>
       <dependency>
          <groupId>javax.inject</groupId>
@@ -227,39 +225,40 @@
          <version>1</version>
       </dependency>
       <dependency>
-         <groupId>javax.enterprise</groupId>
-         <artifactId>cdi-api</artifactId>
-         <version>2.0.SP1</version>
+         <groupId>jakarta.enterprise</groupId>
+         <artifactId>jakarta.enterprise.cdi-api</artifactId>
+         <version>2.0.2</version>
       </dependency>
       <dependency>
          <groupId>org.dom4j</groupId>
          <artifactId>dom4j</artifactId>
-         <version>2.1.1</version>
+         <version>2.1.3</version>
       </dependency>
       <dependency>
          <groupId>org.elasticsearch.client</groupId>
          <artifactId>transport</artifactId>
-         <version>6.6.0</version>
+         <version>7.17.6</version>
       </dependency>
       <dependency>
          <groupId>org.eclipse.californium</groupId>
          <artifactId>californium-core</artifactId>
-         <version>2.0.0</version>
+         <version>2.7.3</version>
       </dependency>
+      <!--version >= 2.12.0 solves the error with jackson-databind 2.12.7-->
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-annotations</artifactId>
-         <version>2.11.2</version>
+         <version>2.12.4</version>
       </dependency>
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
-         <version>2.11.2</version>
+         <version>2.12.7</version>
       </dependency>
       <dependency>
          <groupId>biz.paluch.logging</groupId>
          <artifactId>logstash-gelf</artifactId>
-         <version>1.13.0</version>
+         <version>1.15.0</version>
       </dependency>
       <dependency>
          <groupId>org.apache.commons</groupId>
@@ -269,50 +268,106 @@
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-         <version>1.2.1</version>
+         <version>1.2.2</version>
       </dependency>
-q
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-engine</artifactId>
          <version>${org.junit.jupiter.version}</version>
          <scope>test</scope>
       </dependency>
+      <!-- Vulnerability from dependency jackson-mapper-asl: CVE-2019-10172 -->
       <dependency>
          <groupId>io.rest-assured</groupId>
          <artifactId>rest-assured</artifactId>
-         <version>4.3.1</version>
+         <version>5.1.1</version>
          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>io.moquette</groupId>
          <artifactId>moquette-broker</artifactId>
-         <version>0.13</version>
+         <version>0.15</version>
          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-api</artifactId>
-         <version>2.0.0-alpha1</version>
+         <version>2.0.0</version>
       </dependency>
       <dependency>
          <groupId>org.slf4j</groupId>
-         <artifactId>slf4j-log4j12</artifactId>
-         <version>2.0.0-alpha1</version>
+         <artifactId>slf4j-reload4j</artifactId>
+         <version>2.0.0</version>
          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.eclipse.jetty.http2</groupId>
          <artifactId>http2-client</artifactId>
-         <version>9.4.35.v20201120</version>
+         <version>9.4.48.v20220622</version>
          <scope>test</scope>
       </dependency>
       <dependency>
          <groupId>org.eclipse.jetty.http2</groupId>
          <artifactId>http2-http-client-transport</artifactId>
-         <version>9.4.35.v20201120</version>
+         <version>9.4.48.v20220622</version>
          <scope>test</scope>
       </dependency>
+
+      <!-- Dependency mediation - replacement dependencies of dependencies with vulnerabilities-->
+      <!-- Overrides dependency vulnerability of:
+            exp4j,
+            californium-core,
+            jackson-annotations.
+         CVE-2020-15250 -->
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <version>4.13.2</version>
+         <scope>test</scope>
+      </dependency>
+      <!-- Overrides dependency vulnerability of exp4j CVE-2017-5929 -->
+      <dependency>
+         <groupId>ch.qos.logback</groupId>
+         <artifactId>logback-classic</artifactId>
+         <version>1.3.0</version>
+         <scope>test</scope>
+      </dependency>
+      <!-- Overrides dependency vulnerability of transport CVE-2020-28491 -->
+      <dependency>
+         <groupId>com.fasterxml.jackson.dataformat</groupId>
+         <artifactId>jackson-dataformat-cbor</artifactId>
+         <version>2.13.3</version>
+      </dependency>
+      <!-- Overrides dependency vulnerability of httpclient Cxeb68d52e-5509 -->
+      <dependency>
+         <groupId>commons-codec</groupId>
+         <artifactId>commons-codec</artifactId>
+         <version>1.13</version>
+      </dependency>
+      <!-- Overrides dependency vulnerability of moquette-broker CVE-2021-21295 -->
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-codec-http2</artifactId>
+         <version>4.1.80.Final</version>
+      </dependency>
+      <!-- Overrides dependency vulnerability of moquette-broker -->
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-common</artifactId>
+         <version>4.1.80.Final</version>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-codec</artifactId>
+         <version>4.1.80.Final</version>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-codec-http</artifactId>
+         <version>4.1.80.Final</version>
+      </dependency>
+
+
 
    </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
       <dependency>
          <groupId>org.elasticsearch.client</groupId>
          <artifactId>transport</artifactId>
-         <version>7.17.6</version>
+         <version>7.17.7</version>
       </dependency>
       <dependency>
          <groupId>org.eclipse.californium</groupId>
@@ -252,7 +252,7 @@
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
-         <version>2.12.7</version>
+         <version>2.13.4.2</version>
       </dependency>
       <dependency>
          <groupId>biz.paluch.logging</groupId>
@@ -330,12 +330,6 @@
          <artifactId>logback-classic</artifactId>
          <version>1.3.0</version>
          <scope>test</scope>
-      </dependency>
-      <!-- Overrides dependency vulnerability of transport CVE-2020-28491 -->
-      <dependency>
-         <groupId>com.fasterxml.jackson.dataformat</groupId>
-         <artifactId>jackson-dataformat-cbor</artifactId>
-         <version>2.13.3</version>
       </dependency>
       <!-- Overrides dependency vulnerability of httpclient Cxeb68d52e-5509 -->
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
    <modelVersion>4.0.0</modelVersion>
 
    <groupId>io.patriot-framework</groupId>
-   <version>5.0.0</version>
+   <version>5.0.0-SNAPSHOT</version>
    <artifactId>generator</artifactId>
    <name>Device generator</name>
    <description>Library which is part of PatrIoT Framework responsible for device emulation and data generation.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -355,7 +355,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-javadoc-plugin</artifactId>
                   <configuration>
-                     <source>8</source>
+                     <release>17</release>
                   </configuration>
                   <executions>
                      <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
       <connection>scm:git:git@github.com:PatrIoT-Framework/patriot-data-generator.git</connection>
       <developerConnection>scm:git:git@github.com:PatrIoT-Framework/patriot-data-generator.git</developerConnection>
       <url>https://github.com/PatrIoT-Framework/patriot-data-generator</url>
-     <tag>HEAD</tag>
-  </scm>
+      <tag>HEAD</tag>
+   </scm>
    <licenses>
       <license>
          <name>Apache License, Version 2.0</name>
@@ -143,11 +143,8 @@
       </repository>
    </distributionManagement>
    <properties>
-      <org.junit.platform.version>1.3.0</org.junit.platform.version>
-      <org.junit.jupiter.version>5.4.2</org.junit.jupiter.version>
-      <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
-      <gpg-plugin-version>1.6</gpg-plugin-version>
-      <release-plugin-version>2.5.3</release-plugin-version>
+      <org.junit.jupiter.version>5.9.3</org.junit.jupiter.version>
+      <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
    </properties>
 
    <build>
@@ -155,32 +152,39 @@
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.0</version>
+            <version>3.11.0</version>
             <configuration>
                <release>17</release>
             </configuration>
          </plugin>
+
          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <version>${maven-surefire-plugin.version}</version>
+            <version>3.1.2</version>
          </plugin>
+
          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
+            <version>3.6.0</version>
             <configuration>
                <descriptorRefs>
                   <descriptorRef>jar-with-dependencies</descriptorRef>
                </descriptorRefs>
             </configuration>
          </plugin>
+
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>${gpg-plugin-version}</version>
+            <version>${maven-gpg-plugin.version}</version>
          </plugin>
+
          <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-release-plugin</artifactId>
-            <version>${release-plugin-version}</version>
+            <version>3.0.1</version>
             <configuration>
                <autoVersionSubmodules>true</autoVersionSubmodules>
                <useReleaseProfile>false</useReleaseProfile>
@@ -191,29 +195,26 @@
       </plugins>
    </build>
 
+
    <dependencies>
-      <!-- https://mvnrepository.com/artifact/ca.umontreal.iro.simul/ssj -->
       <dependency>
          <groupId>ca.umontreal.iro.simul</groupId>
          <artifactId>ssj</artifactId>
          <version>3.3.2</version>
       </dependency>
 
-      <!-- https://mvnrepository.com/artifact/org.json/json -->
       <dependency>
          <groupId>org.json</groupId>
          <artifactId>json</artifactId>
          <version>20230618</version>
       </dependency>
 
-      <!--Math Expressions-->
       <dependency>
          <groupId>net.objecthunter</groupId>
          <artifactId>exp4j</artifactId>
          <version>0.4.8</version>
       </dependency>
 
-      <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5 -->
       <dependency>
          <groupId>org.apache.httpcomponents.client5</groupId>
          <artifactId>httpclient5</artifactId>
@@ -261,13 +262,11 @@
          <artifactId>logstash-gelf</artifactId>
          <version>1.15.0</version>
       </dependency>
-      <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
          <version>3.12.0</version>
       </dependency>
-      <!-- https://mvnrepository.com/artifact/org.eclipse.paho/org.eclipse.paho.client.mqttv3 -->
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
@@ -282,6 +281,7 @@
       </dependency>
 
       <!-- test scope begin -->
+
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-engine</artifactId>
@@ -320,7 +320,6 @@
       <!-- Resolve vulnerabilities of from transitive dependencies -->
 
       <!-- ssj -->
-      <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
       <dependency>
          <groupId>com.google.code.gson</groupId>
          <artifactId>gson</artifactId>
@@ -328,7 +327,6 @@
       </dependency>
 
       <!-- transport -->
-      <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
       <dependency>
          <groupId>org.yaml</groupId>
          <artifactId>snakeyaml</artifactId>
@@ -336,13 +334,13 @@
       </dependency>
 
       <!-- logstash-gelf -->
-      <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
       <dependency>
          <groupId>org.apache.logging.log4j</groupId>
          <artifactId>log4j-core</artifactId>
          <version>2.20.0</version>
       </dependency>
    </dependencies>
+
    <profiles>
       <profile>
          <id>release</id>
@@ -354,6 +352,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-javadoc-plugin</artifactId>
+                  <version>3.5.0</version>
                   <configuration>
                      <release>17</release>
                   </configuration>
@@ -369,6 +368,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-gpg-plugin</artifactId>
+                  <version>${maven-gpg-plugin.version}</version>
                   <executions>
                      <execution>
                         <id>sign-artifacts</id>
@@ -382,6 +382,7 @@
                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-source-plugin</artifactId>
+                  <version>3.3.0</version>
                   <executions>
                      <execution>
                         <id>attach-sources</id>

--- a/pom.xml
+++ b/pom.xml
@@ -366,9 +366,6 @@
          <artifactId>netty-codec-http</artifactId>
          <version>4.1.80.Final</version>
       </dependency>
-
-
-
    </dependencies>
 
    <profiles>
@@ -423,12 +420,4 @@
          </build>
       </profile>
    </profiles>
-
-   <repositories>
-      <repository>
-         <id>bintray</id>
-         <url>http://dl.bintray.com/andsel/maven/</url>
-      </repository>
-   </repositories>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
       <dependency>
          <groupId>org.elasticsearch.client</groupId>
          <artifactId>transport</artifactId>
-         <version>7.17.10</version>
+         <version>7.17.12</version>
       </dependency>
       <dependency>
          <groupId>org.eclipse.californium</groupId>
@@ -272,8 +272,6 @@
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
          <version>1.2.4</version>
       </dependency>
-
-
       <dependency>
          <groupId>org.eclipse.jetty.http2</groupId>
          <artifactId>http2-client</artifactId>
@@ -288,28 +286,24 @@
          <version>${org.junit.jupiter.version}</version>
          <scope>test</scope>
       </dependency>
-
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-api</artifactId>
          <version>${org.junit.jupiter.version}</version>
          <scope>test</scope>
       </dependency>
-
       <dependency>
          <groupId>io.rest-assured</groupId>
          <artifactId>rest-assured</artifactId>
          <version>5.1.1</version>
          <scope>test</scope>
       </dependency>
-
       <dependency>
          <groupId>io.moquette</groupId>
          <artifactId>moquette-broker</artifactId>
          <version>0.16</version>
          <scope>test</scope>
       </dependency>
-
       <dependency>
          <groupId>org.eclipse.jetty.http2</groupId>
          <artifactId>http2-http-client-transport</artifactId>
@@ -331,6 +325,16 @@
          <groupId>org.yaml</groupId>
          <artifactId>snakeyaml</artifactId>
          <version>2.0</version>
+      </dependency>
+      <dependency>
+         <groupId>commons-codec</groupId>
+         <artifactId>commons-codec</artifactId>
+         <version>1.16.0</version>
+      </dependency>
+      <dependency>
+         <groupId>org.apache.httpcomponents</groupId>
+         <artifactId>httpclient</artifactId>
+         <version>4.5.14</version>
       </dependency>
 
       <!-- logstash-gelf -->

--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,7 @@
             <artifactId>maven-compiler-plugin</artifactId>
             <version>3.8.0</version>
             <configuration>
-               <source>8</source>
-               <target>8</target>
+               <release>17</release>
             </configuration>
          </plugin>
          <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
    <groupId>io.patriot-framework</groupId>
    <version>5.0.0-SNAPSHOT</version>
    <artifactId>generator</artifactId>
-
    <name>Device generator</name>
    <description>Library which is part of PatrIoT Framework responsible for device emulation and data generation.</description>
    <url>https://patriot-framework.io/</url>
@@ -39,7 +38,6 @@
          <comments>A business-friendly OSS license</comments>
       </license>
    </licenses>
-
    <developers>
       <developer>
          <id>obabec</id>
@@ -143,6 +141,8 @@
       </repository>
    </distributionManagement>
    <properties>
+      <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
       <org.junit.jupiter.version>5.9.3</org.junit.jupiter.version>
       <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
    </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -255,7 +255,7 @@
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
-         <version>2.13.5</version>
+         <version>2.15.2</version>
       </dependency>
       <dependency>
          <groupId>biz.paluch.logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
    <modelVersion>4.0.0</modelVersion>
 
    <groupId>io.patriot-framework</groupId>
-   <version>2.0.1-SNAPSHOT</version>
+   <version>5.0.0-SNAPSHOT</version>
    <artifactId>generator</artifactId>
 
    <name>Device generator</name>
@@ -121,6 +121,16 @@
          </roles>
          <timezone>Europe/Bratislava</timezone>
       </developer>
+      <developer>
+         <id>mstastny</id>
+         <email>mstastny@redhat.com</email>
+         <organization>Red Hat</organization>
+         <name>Marek Šťastný</name>
+         <roles>
+            <role>Developer</role>
+         </roles>
+         <timezone>Europe/Prague</timezone>
+      </developer>
    </developers>
    <distributionManagement>
       <snapshotRepository>
@@ -136,7 +146,6 @@
       <org.junit.platform.version>1.3.0</org.junit.platform.version>
       <org.junit.jupiter.version>5.4.2</org.junit.jupiter.version>
       <maven-surefire-plugin.version>3.0.0-M7</maven-surefire-plugin.version>
-      <slf4j-log4j2-version>2.0.1</slf4j-log4j2-version>
       <gpg-plugin-version>1.6</gpg-plugin-version>
       <release-plugin-version>2.5.3</release-plugin-version>
    </properties>
@@ -187,13 +196,14 @@
       <dependency>
          <groupId>ca.umontreal.iro.simul</groupId>
          <artifactId>ssj</artifactId>
-         <version>3.2.1</version>
+         <version>3.3.2</version>
       </dependency>
 
+      <!-- https://mvnrepository.com/artifact/org.json/json -->
       <dependency>
          <groupId>org.json</groupId>
          <artifactId>json</artifactId>
-         <version>20210307</version>
+         <version>20230618</version>
       </dependency>
 
       <!--Math Expressions-->
@@ -202,22 +212,20 @@
          <artifactId>exp4j</artifactId>
          <version>0.4.8</version>
       </dependency>
+
+      <!-- https://mvnrepository.com/artifact/org.apache.httpcomponents.client5/httpclient5 -->
       <dependency>
-         <groupId>org.apache.httpcomponents</groupId>
-         <artifactId>httpclient</artifactId>
-         <version>4.5.13</version>
+         <groupId>org.apache.httpcomponents.client5</groupId>
+         <artifactId>httpclient5</artifactId>
+         <version>5.2.1</version>
       </dependency>
-      <dependency>
-         <groupId>org.junit.jupiter</groupId>
-         <artifactId>junit-jupiter-api</artifactId>
-         <version>${org.junit.jupiter.version}</version>
-         <scope>test</scope>
-      </dependency>
+
       <dependency>
          <groupId>org.slf4j</groupId>
          <artifactId>slf4j-simple</artifactId>
-         <version>1.7.36</version>
+         <version>2.0.7</version>
       </dependency>
+
       <dependency>
          <groupId>javax.inject</groupId>
          <artifactId>javax.inject</artifactId>
@@ -226,141 +234,115 @@
       <dependency>
          <groupId>jakarta.enterprise</groupId>
          <artifactId>jakarta.enterprise.cdi-api</artifactId>
-         <version>2.0.2</version>
+         <version>4.0.1</version>
       </dependency>
       <dependency>
          <groupId>org.dom4j</groupId>
          <artifactId>dom4j</artifactId>
-         <version>2.1.3</version>
+         <version>2.1.4</version>
       </dependency>
       <dependency>
          <groupId>org.elasticsearch.client</groupId>
          <artifactId>transport</artifactId>
-         <version>7.17.7</version>
+         <version>7.17.10</version>
       </dependency>
       <dependency>
          <groupId>org.eclipse.californium</groupId>
          <artifactId>californium-core</artifactId>
          <version>2.7.3</version>
       </dependency>
-      <!--version >= 2.12.0 solves the error with jackson-databind 2.12.7-->
-      <dependency>
-         <groupId>com.fasterxml.jackson.core</groupId>
-         <artifactId>jackson-annotations</artifactId>
-         <version>2.12.4</version>
-      </dependency>
       <dependency>
          <groupId>com.fasterxml.jackson.core</groupId>
          <artifactId>jackson-databind</artifactId>
-         <version>2.13.4.2</version>
+         <version>2.13.5</version>
       </dependency>
       <dependency>
          <groupId>biz.paluch.logging</groupId>
          <artifactId>logstash-gelf</artifactId>
          <version>1.15.0</version>
       </dependency>
+      <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
       <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
-         <version>3.9</version>
+         <version>3.12.0</version>
       </dependency>
+      <!-- https://mvnrepository.com/artifact/org.eclipse.paho/org.eclipse.paho.client.mqttv3 -->
       <dependency>
          <groupId>org.eclipse.paho</groupId>
          <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
-         <version>1.2.2</version>
+         <version>1.2.4</version>
       </dependency>
+
+
+      <dependency>
+         <groupId>org.eclipse.jetty.http2</groupId>
+         <artifactId>http2-client</artifactId>
+         <version>11.0.15</version>
+      </dependency>
+
+      <!-- test scope begin -->
       <dependency>
          <groupId>org.junit.jupiter</groupId>
          <artifactId>junit-jupiter-engine</artifactId>
          <version>${org.junit.jupiter.version}</version>
          <scope>test</scope>
       </dependency>
-      <!-- Vulnerability from dependency jackson-mapper-asl: CVE-2019-10172 -->
+
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter-api</artifactId>
+         <version>${org.junit.jupiter.version}</version>
+         <scope>test</scope>
+      </dependency>
+
       <dependency>
          <groupId>io.rest-assured</groupId>
          <artifactId>rest-assured</artifactId>
          <version>5.1.1</version>
          <scope>test</scope>
       </dependency>
+
       <dependency>
          <groupId>io.moquette</groupId>
          <artifactId>moquette-broker</artifactId>
-         <version>0.15</version>
+         <version>0.16</version>
          <scope>test</scope>
       </dependency>
-      <dependency>
-         <groupId>org.slf4j</groupId>
-         <artifactId>slf4j-api</artifactId>
-         <version>2.0.0</version>
-      </dependency>
-      <dependency>
-         <groupId>org.slf4j</groupId>
-         <artifactId>slf4j-reload4j</artifactId>
-         <version>2.0.0</version>
-         <scope>test</scope>
-      </dependency>
-      <dependency>
-         <groupId>org.eclipse.jetty.http2</groupId>
-         <artifactId>http2-client</artifactId>
-         <version>9.4.48.v20220622</version>
-         <scope>test</scope>
-      </dependency>
+
       <dependency>
          <groupId>org.eclipse.jetty.http2</groupId>
          <artifactId>http2-http-client-transport</artifactId>
-         <version>9.4.48.v20220622</version>
+         <version>11.0.15</version>
          <scope>test</scope>
       </dependency>
 
-      <!-- Dependency mediation - replacement dependencies of dependencies with vulnerabilities-->
-      <!-- Overrides dependency vulnerability of:
-            exp4j,
-            californium-core,
-            jackson-annotations.
-         CVE-2020-15250 -->
+      <!-- Resolve vulnerabilities of from transitive dependencies -->
+
+      <!-- ssj -->
+      <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
       <dependency>
-         <groupId>junit</groupId>
-         <artifactId>junit</artifactId>
-         <version>4.13.2</version>
-         <scope>test</scope>
+         <groupId>com.google.code.gson</groupId>
+         <artifactId>gson</artifactId>
+         <version>2.10.1</version>
       </dependency>
-      <!-- Overrides dependency vulnerability of exp4j CVE-2017-5929 -->
+
+      <!-- transport -->
+      <!-- https://mvnrepository.com/artifact/org.yaml/snakeyaml -->
       <dependency>
-         <groupId>ch.qos.logback</groupId>
-         <artifactId>logback-classic</artifactId>
-         <version>1.3.0</version>
-         <scope>test</scope>
+         <groupId>org.yaml</groupId>
+         <artifactId>snakeyaml</artifactId>
+         <version>2.0</version>
       </dependency>
-      <!-- Overrides dependency vulnerability of httpclient Cxeb68d52e-5509 -->
+
+      <!-- logstash-gelf -->
+      <!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
       <dependency>
-         <groupId>commons-codec</groupId>
-         <artifactId>commons-codec</artifactId>
-         <version>1.13</version>
-      </dependency>
-      <!-- Overrides dependency vulnerability of moquette-broker CVE-2021-21295 -->
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec-http2</artifactId>
-         <version>4.1.80.Final</version>
-      </dependency>
-      <!-- Overrides dependency vulnerability of moquette-broker -->
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-common</artifactId>
-         <version>4.1.80.Final</version>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec</artifactId>
-         <version>4.1.80.Final</version>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec-http</artifactId>
-         <version>4.1.80.Final</version>
+         <groupId>org.apache.logging.log4j</groupId>
+         <artifactId>log4j-core</artifactId>
+         <version>2.20.0</version>
       </dependency>
    </dependencies>
-
    <profiles>
       <profile>
          <id>release</id>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
    <modelVersion>4.0.0</modelVersion>
 
    <groupId>io.patriot-framework</groupId>
-   <version>5.0.0-SNAPSHOT</version>
+   <version>5.0.0</version>
    <artifactId>generator</artifactId>
    <name>Device generator</name>
    <description>Library which is part of PatrIoT Framework responsible for device emulation and data generation.</description>

--- a/src/main/java/io/patriot_framework/generator/device/consumer/http/Server.java
+++ b/src/main/java/io/patriot_framework/generator/device/consumer/http/Server.java
@@ -30,7 +30,7 @@ import io.patriot_framework.generator.device.consumer.Storage;
 import io.patriot_framework.generator.device.consumer.exceptions.ConsumerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.net.InetSocketAddress;
 import java.nio.channels.UnresolvedAddressException;
@@ -121,6 +121,6 @@ public final class Server extends AbstractDevice implements Consumer {
 
     @Override
     public List<Data> requestData(Object... params) {
-        throw new NotImplementedException();
+        throw new NotImplementedException("");
     }
 }

--- a/src/main/java/io/patriot_framework/generator/device/consumer/mqtt/MqttConsumer.java
+++ b/src/main/java/io/patriot_framework/generator/device/consumer/mqtt/MqttConsumer.java
@@ -27,7 +27,7 @@ import org.eclipse.paho.client.mqttv3.MqttAsyncClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 
 import java.util.List;
 
@@ -90,6 +90,6 @@ public final class MqttConsumer extends AbstractDevice implements Consumer {
 
     @Override
     public List<Data> requestData(Object... params) {
-        throw new NotImplementedException();
+        throw new NotImplementedException("");
     }
 }


### PR DESCRIPTION
This PR includes:

- bump project version to 5.0.0-SNAPSHOT,
- bump Java version from 8 to 17,
- bump dependencies with vulnerabilities,
- remove bintray repository (not used anymore),
- bump plugin versions,
- setup source encoding to UTF8.